### PR TITLE
Add map argument for php backend

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -24,13 +24,14 @@ http {
 
     client_max_body_size 32M;
 
-    map $cookie_xdebug $backend {
+    map $cookie_xdebug $default_backend {
         default php;
         on      php-xdebug;
     }
 
     map $arg_xdebug $backend {
-        default php;
+        default $default_backend;
+        off     php;
         on      php-xdebug;
     }
 

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -29,6 +29,11 @@ http {
         on      php-xdebug;
     }
 
+    map $arg_xdebug $backend {
+        default php;
+        on      php-xdebug;
+    }
+
     upstream php {
         server php:9000;
     }


### PR DESCRIPTION
Tested this locally and it works simply by appending `?xdebug=on` as a query arg to the url.